### PR TITLE
Add a GitHub Action for Sweet B builds and tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,5 @@
 #
-# .travis.yml: Travis CI support
+# build-and-test.yml: GitHub Action for building and testing
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -8,7 +8,7 @@
 #
 # https://github.com/westerndigitalcorporation/sweet-b
 #
-# Copyright (c) 2020 Western Digital Corporation or its affiliates.
+# Copyright (c) 2022 Western Digital Corporation or its affiliates.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -37,53 +37,38 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-language: c
+name: Build and Test
 
-matrix:
-  include:
-    - os: linux
-      compiler: gcc
-      dist: trusty
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-7
-            - cmake3
-      env:
-        - C_COMPILER=gcc-7
+on: [push, pull_request]
 
-    - os: linux
-      compiler: clang
-      dist: trusty
-      env:
-        - ASAN_OPTIONS=detect_leaks=0
-        - C_COMPILER=clang
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
 
-    - os: linux
-      compiler: gcc
-      dist: trusty
-      addons:
-        apt:
-          packages:
-            - gcc-arm-linux-gnueabihf
-            - libc6-dev-armhf-cross
-            - qemu-user
-      env:
-        - CMAKE_EXTRA="-DCMAKE_TOOLCHAIN_FILE=arm.cmake"
-        - RUN_WRAP=qemu-arm
+    strategy:
+      fail-fast: true
+      matrix:
+        configuration: [Debug, Release]
+        processor: [default, arm]
+        include:
+          - processor: default
+            toolchain-option: "-DCMAKE_C_COMPILER=clang"
+          - processor: arm
+            toolchain-option: "-DCMAKE_TOOLCHAIN_FILE=arm.cmake"
+            run-wrap: qemu-arm
+            packages: gcc-arm-linux-gnueabihf libc6-dev-armhf-cross qemu-user
 
-#    - os: osx
-#      compiler: clang
-#      osx_image: xcode9
+    steps:
+    - uses: actions/checkout@v3
 
-before_script:
-  - mkdir cmake-build-debug
-  - cd cmake-build-debug
-  - cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=$C_COMPILER $CMAKE_EXTRA
+    - name: system-packages
+      if: ${{ matrix.packages != '' }}
+      run: sudo apt install -y ${{ matrix.packages }}
 
-script:
-  - make VERBOSE=1
-  - cd ..
-  - $RUN_WRAP ./cmake-build-debug/sb_test
+    - name: build
+      run: |
+        cmake -Bcmake-build -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} ${{ matrix.toolchain-option }} -DSB_TEST=1
+        make -Ccmake-build VERBOSE=1
+    
+    - name: test
+      run: ${{matrix.run-wrap}} ./cmake-build/sb_test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,5 @@
 #
-# .gitignore: what it says on the tin
+# build-and-test.yml: CodeQL support for Sweet B
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -8,7 +8,7 @@
 #
 # https://github.com/westerndigitalcorporation/sweet-b
 #
-# Copyright (c) 2020 Western Digital Corporation or its affiliates.
+# Copyright (c) 2022 Western Digital Corporation or its affiliates.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -37,12 +37,30 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-.idea
-sweet_b
-*.o
-cmake-build-*
-callgrind.out.*
-*~
-*.dSYM
-.vscode
-sb_test
+name: CodeQL
+
+on: [push, pull_request]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: cpp
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/src/sb_sw_lib_tests.c.h
+++ b/src/sb_sw_lib_tests.c.h
@@ -1308,9 +1308,9 @@ static _Bool test_small_r_signature(sb_sw_curve_id_t curve)
         sb_fe_add(&candidate_r, &candidate_r, &SB_FE_ONE);
 
         t++;
-    } while (t < 1024); // we should find a candidate on any curve pretty quickly
+        SB_TEST_ASSERT(t < 1024); // we should find a candidate on any curve pretty quickly
+    } while (1);
 
-    // We didn't find a small r
     return 0;
 }
 

--- a/src/sb_sw_lib_tests.c.h
+++ b/src/sb_sw_lib_tests.c.h
@@ -1279,6 +1279,7 @@ static _Bool test_small_r_signature(sb_sw_curve_id_t curve)
     sb_sw_public_t keys[4];
     sb_sw_context_t m;
     sb_sw_curve_t const* s;
+    size_t t = 0;
 
     SB_TEST_ASSERT_SUCCESS(sb_sw_curve_from_id(&s, curve));
 
@@ -1305,7 +1306,12 @@ static _Bool test_small_r_signature(sb_sw_curve_id_t curve)
         }
 
         sb_fe_add(&candidate_r, &candidate_r, &SB_FE_ONE);
-    } while (1);
+
+        t++;
+    } while (t < 1024); // we should find a candidate on any curve pretty quickly
+
+    // We didn't find a small r
+    return 0;
 }
 
 // When verifying signatures it is possible to have a signature that won't

--- a/src/sb_sw_lib_tests.c.h
+++ b/src/sb_sw_lib_tests.c.h
@@ -1310,8 +1310,6 @@ static _Bool test_small_r_signature(sb_sw_curve_id_t curve)
         t++;
         SB_TEST_ASSERT(t < 1024); // we should find a candidate on any curve pretty quickly
     } while (1);
-
-    return 0;
 }
 
 // When verifying signatures it is possible to have a signature that won't


### PR DESCRIPTION
Fixes #1. Tests are run in both debug and release configurations on the default runner architecture and on 32-bit ARM as emulated by QEMU, the latter testing the ARM assembly code. A CodeQL action is also added.