### PR TITLE
Added Unit Test for Psychic Paper Attack

### DIFF
--- a/src/sb_sw_lib.c
+++ b/src/sb_sw_lib.c
@@ -1086,7 +1086,9 @@ static _Bool sb_sw_verify_continue(sb_sw_context_t v[static const 1],
 
     switch (state.stage) {
         case SB_SW_VERIFY_OP_STAGE_INV_S: {
-            // A signature with either r or s as 0 or N is invalid
+            // A signature with either r or s as 0 or N is invalid;
+            // see `sb_test_invalid_sig` for a unit test of this
+            // check.
             state.res &= sb_sw_scalar_validate(VERIFY_QR(v), s);
             state.res &= sb_sw_scalar_validate(VERIFY_QS(v), s);
             sb_fe_mod_reduce(VERIFY_MESSAGE(v), s->n);

--- a/src/sb_sw_lib.c
+++ b/src/sb_sw_lib.c
@@ -1086,6 +1086,7 @@ static _Bool sb_sw_verify_continue(sb_sw_context_t v[static const 1],
 
     switch (state.stage) {
         case SB_SW_VERIFY_OP_STAGE_INV_S: {
+            // A signature with either r or s as 0 or N is invalid
             state.res &= sb_sw_scalar_validate(VERIFY_QR(v), s);
             state.res &= sb_sw_scalar_validate(VERIFY_QS(v), s);
             sb_fe_mod_reduce(VERIFY_MESSAGE(v), s->n);

--- a/src/sb_sw_lib_tests.c.h
+++ b/src/sb_sw_lib_tests.c.h
@@ -1621,9 +1621,9 @@ _Bool sb_test_sw_invalid_scalar(void)
 }
 
 // Test that sweet-b is not vulnerable to the "Psychic Paper" attack.
-// More specifically, verify that for some signature (r, s) if r or s = 0
+// More specifically, verify that for some signature (r, s) if r or s = 0 or N
 // signature verification returns invalid.
-static _Bool sb_test_invalid_sig(const sb_byte_t invalid[static const 1],
+static _Bool sb_test_invalid_sig(const sb_byte_t invalid[static const SB_ELEM_BYTES],
                                  const sb_sw_curve_id_t c,
                                  const sb_data_endian_t e)
 {
@@ -1648,14 +1648,14 @@ static _Bool sb_test_invalid_sig(const sb_byte_t invalid[static const 1],
     SB_TEST_ASSERT_SUCCESS(sb_hmac_drbg_generate_additional_dummy
                                     (&drbg, s2.bytes, sizeof(s2.bytes)));
 
-    // Set half the signature to 0 and make sure we get an error 
+    // Set half the signature to 0 or N and make sure we get an error 
     memcpy(s1.bytes, invalid, SB_ELEM_BYTES);
     SB_TEST_ASSERT_ERROR(
         sb_sw_verify_signature(&ct, &s1, &pub, 
                                &TEST_MESSAGE_PKR, &drbg, c, e), 
         SB_ERROR_SIGNATURE_INVALID);
 
-    // Test with a signature with the other half as 0 and 
+    // Test with a signature with the other half as 0 or N and 
     // make sure we still get an error
     memcpy(s2.bytes + SB_ELEM_BYTES, invalid, SB_ELEM_BYTES);
     SB_TEST_ASSERT_ERROR(
@@ -1663,7 +1663,7 @@ static _Bool sb_test_invalid_sig(const sb_byte_t invalid[static const 1],
                               &TEST_MESSAGE_PKR, &drbg, c, e), 
         SB_ERROR_SIGNATURE_INVALID);
 
-    // Make the whole signature 0 and make sure we get an error
+    // Make both r and s 0 or N and make sure we get an error
     memcpy(s2.bytes, invalid, SB_ELEM_BYTES);
     SB_TEST_ASSERT_ERROR(
         sb_sw_verify_signature(&ct, &s2, &pub, 

--- a/src/sb_sw_lib_tests.c.h
+++ b/src/sb_sw_lib_tests.c.h
@@ -1679,7 +1679,7 @@ _Bool sb_test_sw_invalid_sig_p256(void) {
     sb_byte_t zeros[SB_ELEM_BYTES] = {0};
 
     sb_byte_t n[SB_ELEM_BYTES];
-    sb_sw_curve_t* s = NULL;
+    const sb_sw_curve_t* s = NULL;
     SB_TEST_ASSERT_SUCCESS(
         sb_sw_curve_from_id(&s, SB_SW_CURVE_P256));
 
@@ -1699,7 +1699,7 @@ _Bool sb_test_sw_invalid_sig_secp256k1(void) {
     sb_byte_t zeros[SB_ELEM_BYTES] = {0};
 
     sb_byte_t n[SB_ELEM_BYTES];
-    sb_sw_curve_t* s = NULL;
+    const sb_sw_curve_t* s = NULL;
     SB_TEST_ASSERT_SUCCESS(
         sb_sw_curve_from_id(&s, SB_SW_CURVE_SECP256K1));
 

--- a/src/sb_test_list.h
+++ b/src/sb_test_list.h
@@ -100,8 +100,8 @@ SB_DEFINE_TEST(pk_recovery_james);
 SB_DEFINE_TEST(candidates);
 SB_DEFINE_TEST(sw_early_errors);
 SB_DEFINE_TEST(sw_invalid_scalar);
-SB_DEFINE_TEST(sw_sign_zero_p256);
-SB_DEFINE_TEST(sw_sign_zero_secp256k1);
+SB_DEFINE_TEST(sw_invalid_sig_p256);
+SB_DEFINE_TEST(sw_invalid_sig_secp256k1);
 // Randomized tests for expected functionality.
 // Each takes a drbg and at each iteration generates a keypair to run tests.
 SB_DEFINE_TEST(composite_key_wrap_p256);

--- a/src/sb_test_list.h
+++ b/src/sb_test_list.h
@@ -100,6 +100,8 @@ SB_DEFINE_TEST(pk_recovery_james);
 SB_DEFINE_TEST(candidates);
 SB_DEFINE_TEST(sw_early_errors);
 SB_DEFINE_TEST(sw_invalid_scalar);
+SB_DEFINE_TEST(sw_sign_zero_p256);
+SB_DEFINE_TEST(sw_sign_zero_secp256k1);
 // Randomized tests for expected functionality.
 // Each takes a drbg and at each iteration generates a keypair to run tests.
 SB_DEFINE_TEST(composite_key_wrap_p256);


### PR DESCRIPTION
Created a new unit test that ensures that for any signature the r and s components are each are verified to be nonzero.