### PR TITLE
Suppress duplicate action runs in a PR between branches of the same repository

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,6 +43,12 @@ on: [push, pull_request]
 
 jobs:
   build-and-test:
+
+    # Don't run duplicate `push` jobs for PRs within the same repository.
+    # Solution from https://github.com/briansmith/ring/blob/0f3bf0031a8dbba741b26f1f02ebde6b7db4a3d6/.github/workflows/ci.yml#L9-L10
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
+    name: "Build and Test"
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,5 @@
 #
-# build-and-test.yml: CodeQL support for Sweet B
+# codeql.yml: CodeQL support for Sweet B
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -43,6 +43,11 @@ on: [push, pull_request]
 
 jobs:
   analyze:
+
+    # Don't run duplicate `push` jobs for PRs within the same repository.
+    # Solution from https://github.com/briansmith/ring/blob/0f3bf0031a8dbba741b26f1f02ebde6b7db4a3d6/.github/workflows/ci.yml#L9-L10
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
     name: Analyze
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Adopt a solution suggested by @briansmith to suppress the duplicate actions run in the context of a PR between branches of one repository.