### PR TITLE
Timecop Integration

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: true
       matrix:
         configuration: [Debug, Release]
-        processor: [default, arm]
+        processor: [default, arm, timecop]
         include:
           - processor: default
             toolchain-option: "-DCMAKE_C_COMPILER=clang"
@@ -63,6 +63,10 @@ jobs:
             toolchain-option: "-DCMAKE_TOOLCHAIN_FILE=arm.cmake"
             run-wrap: qemu-arm
             packages: gcc-arm-linux-gnueabihf libc6-dev-armhf-cross qemu-user
+          - processor: timecop
+            toolchain-option: "-DSB_TIME=1 -DSB_TEST_VERIFY_QR=0"
+            run-wrap: valgrind --exit-errorcode=255
+            packages: valgrind
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -65,7 +65,7 @@ jobs:
             packages: gcc-arm-linux-gnueabihf libc6-dev-armhf-cross qemu-user
           - processor: timecop
             toolchain-option: "-DSB_TIME=1 -DSB_TEST_VERIFY_QR=0"
-            run-wrap: valgrind --exit-errorcode=255
+            run-wrap: valgrind --error-exitcode=255
             packages: valgrind
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ callgrind.out.*
 *.dSYM
 .vscode
 sb_test
+build
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ callgrind.out.*
 *.dSYM
 .vscode
 sb_test
+build

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ callgrind.out.*
 .vscode
 sb_test
 build
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" OR
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Weverything -Wno-padded -Wno-c++98-compat -Wno-documentation-unknown-command")
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fsanitize=undefined -fsanitize=address")
 endif()
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_POSIX_C_SOURCE=200112L -Wall -pedantic -Wextra")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_POSIX_C_SOURCE=200112L -Wall -pedantic -Wextra -g -O0")
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Werror")
 
 include_directories(include)
@@ -118,12 +118,16 @@ if(SB_TEST)
         set(SB_TEST_VERIFY_QR "1" CACHE STRING "")
     endif()
 
+    if(NOT DEFINED SB_TIME)
+        set(SB_TIME "1" CACHE STRING "")
+    endif()
+
     target_compile_definitions(sb_test PRIVATE
             SB_TEST
             SB_WORD_SIZE=${SB_TEST_WORD_SIZE}
             SB_FE_VERIFY_QR=${SB_TEST_VERIFY_QR}
             SB_FE_ASM=${SB_FE_ASM}
-            SB_DEBUG_ASSERTS
+            SB_TIME=${SB_TIME}
             SB_UNROLL=3
             SB_HMAC_DRBG_RESEED_INTERVAL=18
             SB_HMAC_DRBG_MAX_BYTES_PER_REQUEST=128

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" OR
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Weverything -Wno-padded -Wno-c++98-compat -Wno-documentation-unknown-command")
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fsanitize=undefined -fsanitize=address")
 endif()
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_POSIX_C_SOURCE=200112L -Wall -pedantic -Wextra -g -O0")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_POSIX_C_SOURCE=200112L -Wall -pedantic -Wextra")
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Werror")
 
 include_directories(include)
@@ -114,12 +114,16 @@ if(SB_TEST)
         set(SB_TEST_WORD_SIZE "2" CACHE STRING "")
     endif()
 
-    if(NOT DEFINED SB_TEST_VERIFY_QR)
-        set(SB_TEST_VERIFY_QR "1" CACHE STRING "")
+    if(NOT DEFINED SB_TIME)
+        set(SB_TIME "0" CACHE STRING "")
     endif()
 
-    if(NOT DEFINED SB_TIME)
-        set(SB_TIME "1" CACHE STRING "")
+    if(SB_TIME)
+        set(SB_TEST_VERIFY_QR "0" CACHE STRING "")
+    endif()
+
+    if(NOT DEFINED SB_TEST_VERIFY_QR)
+        set(SB_TEST_VERIFY_QR "1" CACHE STRING "")
     endif()
 
     target_compile_definitions(sb_test PRIVATE

--- a/src/sb_fe.c
+++ b/src/sb_fe.c
@@ -103,7 +103,6 @@ void sb_fe_to_bytes(sb_byte_t dest[static const restrict SB_ELEM_BYTES],
 // Returns an all-0 or all-1 word given a boolean flag 0 or 1 (respectively)
 static inline sb_word_t sb_word_mask(const sb_word_t a)
 {
-    sb_unpoison_output(&a, sizeof(sb_word_t));
     SB_ASSERT((a == 0 || a == 1), "word used for ctc must be 0 or 1");
     return (sb_word_t) -a;
 }

--- a/src/sb_fe.c
+++ b/src/sb_fe.c
@@ -103,6 +103,7 @@ void sb_fe_to_bytes(sb_byte_t dest[static const restrict SB_ELEM_BYTES],
 // Returns an all-0 or all-1 word given a boolean flag 0 or 1 (respectively)
 static inline sb_word_t sb_word_mask(const sb_word_t a)
 {
+    sb_unpoison_output(&a, sizeof(sb_word_t));
     SB_ASSERT((a == 0 || a == 1), "word used for ctc must be 0 or 1");
     return (sb_word_t) -a;
 }

--- a/src/sb_fe.h
+++ b/src/sb_fe.h
@@ -46,6 +46,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include "sb_types.h"
+#include "sb_time.h"
 
 /** @name Field element implementation
   *

--- a/src/sb_fe.h
+++ b/src/sb_fe.h
@@ -678,6 +678,18 @@ extern void sb_fe_mod_reduce(sb_fe_t dest[static restrict 1],
                              const sb_prime_field_t p[static restrict 1]);
 
 /**
+ * @brief Constant-time modular full reduction.
+ * 
+ * Restores a quasi-reduced value in the range [1, p] to one that is
+ * reduced to the range [0, p - 1].
+ * 
+ * @param [in,out] dest The field element to be fully reduced.
+ * @param [in] p The prime field to compute the reduction with respect to.
+ */
+extern void sb_fe_mod_reduce_full(sb_fe_t dest[static restrict 1],
+                                  const sb_prime_field_t p[static restrict 1]);
+
+/**
  * @brief Constant-time modular addition.
  *
  * Places the quasi-reduced result of the modular addition \p left + \p right
@@ -709,6 +721,23 @@ extern void sb_fe_mod_add(sb_fe_t dest[static 1],
 extern void sb_fe_mod_double(sb_fe_t dest[static 1],
                              const sb_fe_t left[static 1],
                              const sb_prime_field_t p[static 1]);
+
+/**
+ * @brief Constant-time modular halving.
+ *
+ * Places the quasi-reduced result of the modular halving \p left / 2 in \p
+ * dest.
+ *
+ * @param [out] dest Result of the modular halving. May alias \p left.
+ * @param [in] left The value to be halved.
+ * @param [in] temp A temporary field element to use in the computation.
+ * @param [in] p The prime field for the modular operation.
+ */
+
+extern void sb_fe_mod_halve(sb_fe_t dest[static 1],
+                            const sb_fe_t left[static 1],
+                            sb_fe_t temp[static 1],
+                            const sb_prime_field_t p[static 1]);
 
 /**
  * @brief Constant-time modular subtraction.

--- a/src/sb_hkdf.c
+++ b/src/sb_hkdf.c
@@ -40,6 +40,7 @@
  */
 
 #include "sb_test.h"
+#include "sb_time.h"
 #include <sb_hkdf.h>
 #include <string.h>
 
@@ -48,6 +49,9 @@ void sb_hkdf_extract_init(sb_hkdf_state_t hkdf[static const restrict 1],
                           size_t const salt_len)
 {
     memset(hkdf, 0, sizeof(sb_hkdf_state_t));
+
+    // Indicate that this method's runtime should not depend on salt's value
+    sb_poison_input(salt, salt_len);
 
     // if salt is not provided, it is set to a string of HashLen zeros (RFC5869)
     if (salt_len > 0) {
@@ -94,6 +98,10 @@ void sb_hkdf_kdf_init(sb_hkdf_state_t hkdf[static const restrict 1],
                       size_t const input_len)
 {
     memset(hkdf, 0, sizeof(sb_hkdf_state_t));
+
+    // Indicate that this method's runtime should not depend on input's value
+    sb_poison_input(input, input_len);
+
     sb_hmac_sha256_init(&hkdf->hmac, input, input_len);
 }
 
@@ -105,6 +113,10 @@ void sb_hkdf_expand(sb_hkdf_state_t hkdf[static const restrict 1],
 {
     size_t bytes_produced = 0;
     sb_byte_t iter = 1;
+
+    // Indicate that this method's runtime should not depend on info's value
+    sb_poison_input(info, info_len);
+
     while (bytes_produced < output_len) {
         size_t bytes = output_len - bytes_produced;
         if (bytes > SB_SHA256_SIZE) {

--- a/src/sb_hmac_sha256.c
+++ b/src/sb_hmac_sha256.c
@@ -41,6 +41,7 @@
 
 #include "sb_test.h"
 #include "sb_hmac_sha256.h"
+#include "sb_time.h"
 #include <string.h>
 
 static const sb_byte_t ipad = 0x36;
@@ -60,6 +61,10 @@ void sb_hmac_sha256_init(sb_hmac_sha256_state_t hmac[static const restrict 1],
                          size_t const keylen)
 {
     memset(hmac, 0, sizeof(sb_hmac_sha256_state_t));
+
+    // Indicate that this method's runtime should not depend on
+    // the value of key
+    sb_poison_input(key, keylen);
 
     if (keylen > SB_SHA256_BLOCK_SIZE) {
         sb_sha256_init(&hmac->sha);
@@ -88,7 +93,7 @@ void sb_hmac_sha256_update(sb_hmac_sha256_state_t hmac[static const restrict 1],
                            const sb_byte_t* const restrict input,
                            const size_t len)
 {
-    sb_sha256_update(&hmac->sha, input, len);
+    sb_sha256_update(&hmac->sha, input, len); 
 }
 
 void sb_hmac_sha256_finish(sb_hmac_sha256_state_t hmac[static const restrict 1],

--- a/src/sb_sha256.c
+++ b/src/sb_sha256.c
@@ -203,6 +203,10 @@ void sb_sha256_update(sb_sha256_state_t sha[static const restrict 1],
                       const sb_byte_t* restrict input,
                       size_t len)
 {
+    // Indicate that this method's runtime should not depend on
+    // the value of input
+    sb_poison_input(input, len);
+
     while (len > 0) {
         const size_t fill = sha->total_bytes % SB_SHA256_BLOCK_SIZE;
         const size_t remaining = SB_SHA256_BLOCK_SIZE - fill;
@@ -392,7 +396,6 @@ _Bool sb_test_sha256_cavp_file(const char* file)
                        SB_TEST_STRINGIFY(SB_SHA256_SIZE)
                        "]"));
     while (sb_test_fetch_next_int(tests, &len)) {
-        sb_test_progress(count, 0);
         count++;
 
         SB_TEST_ASSERT(!(len & 0x7u));
@@ -418,8 +421,6 @@ _Bool sb_test_sha256_cavp_file(const char* file)
         sb_sha256_finish(&ctx, hash_out);
         SB_TEST_ASSERT_EQUAL(hash.buf[0], hash_out);
     }
-
-    sb_test_progress(count, 1);
 
     sb_test_buf_free(&message);
     sb_test_buf_free(&hash);
@@ -449,8 +450,6 @@ _Bool sb_test_sha256_cavp_file_monte(const char* file)
     while (sb_test_fetch_next_int(tests, &count)) {
         SB_TEST_ASSERT(count == i);
         i++;
-
-        sb_test_progress(count, 0);
 
         SB_TEST_ASSERT(sb_test_fetch_next_value(tests, &hash));
         SB_TEST_BYTES_RAW(&hash);
@@ -485,8 +484,6 @@ _Bool sb_test_sha256_cavp_file_monte(const char* file)
 
         SB_TEST_ASSERT_EQUAL(hash.buf[0], md[3]);
     }
-
-    sb_test_progress(count, 1);
 
     sb_test_buf_free(&seed);
     sb_test_buf_free(&hash);

--- a/src/sb_sw_curves.h
+++ b/src/sb_sw_curves.h
@@ -67,6 +67,7 @@ typedef struct sb_sw_curve_t {
     // multiplied by R
     sb_fe_pair_t h_r; // H = (2^257 - 1)^-1 * G, with X and Y multiplied by R
     sb_fe_pair_t g_h_r; // G + H, with X and Y multiplied by R
+    sb_fe_pair_t dz_r; // 2 * (0, √𝐵) where √𝐵 has sign bit 0, if such a point exists
     sb_sw_curve_id_t id; // the curve ID for this curve
 } sb_sw_curve_t;
 
@@ -156,6 +157,12 @@ static const sb_sw_curve_t SB_CURVE_P256 = {
                        &SB_CURVE_P256_P),
         SB_FE_CONST_QR(0xD041EE1CCC6223C9, 0xCD81EFC57B6F0943,
                        0xC614355C4D10A425, 0x3A1739581FCABBB7, &SB_CURVE_P256_P)
+    },
+    .dz_r = {
+        SB_FE_CONST_QR(0x2D0F1BE2B5577CF9, 0x8DECDF26C01CE141,
+                       0x07E28A0D562D7881, 0x8218884B2F38E1D6, &SB_CURVE_P256_P),
+        SB_FE_CONST_QR(0x707320391E7826FA, 0x36925B3CB704A1FC,
+                       0xE77DA7D78929B20A, 0x747C0826CD4F4E7B, &SB_CURVE_P256_P)
     },
     .id = SB_SW_CURVE_P256
 };
@@ -247,6 +254,15 @@ static const sb_sw_curve_t SB_CURVE_SECP256K1 = {
                        &SB_CURVE_SECP256K1_P),
         SB_FE_CONST_QR(0x3FB97A191E4DE5EA, 0xBBA21827B7EFEC04,
                        0xC7B977CC32E0BAA9, 0xC374BB2A1315A22F,
+                       &SB_CURVE_SECP256K1_P)
+    },
+    // There is no point with an X coordinate of 0 on this
+    // curve, but quasi-reduced values for dz_r still must be
+    // supplied.
+    .dz_r = {
+        SB_FE_CONST_QR(0, 0, 0, 1,
+                       &SB_CURVE_SECP256K1_P),
+        SB_FE_CONST_QR(0, 0, 0, 1,
                        &SB_CURVE_SECP256K1_P)
     },
     .id = SB_SW_CURVE_SECP256K1

--- a/src/sb_sw_lib.c
+++ b/src/sb_sw_lib.c
@@ -47,6 +47,7 @@
 #include "sb_hkdf.h"
 #include "sb_error.h"
 #include "sb_test_cavp.h"
+#include "sb_time.h"
 
 #include <stddef.h>
 #include <string.h>
@@ -914,7 +915,7 @@ sb_sw_point_validate(sb_sw_context_t c[static const 1],
     r &= !sb_fe_equal(&MULT_POINT(c)->y, &SB_FE_ZERO);
 
     // 5.6.2.3.4 step 2: unreduced points are not valid.
-    r &= (sb_fe_lt(&MULT_POINT(c)->x, &s->p->p) &&
+    r &= (sb_fe_lt(&MULT_POINT(c)->x, &s->p->p) &
           sb_fe_lt(&MULT_POINT(c)->y, &s->p->p));
 
     // Valid Y values are now ensured to be quasi-reduced. Invalid Y values
@@ -1357,6 +1358,10 @@ sb_error_t sb_sw_hkdf_expand_private_key(sb_sw_context_t ctx[static const 1],
 {
     sb_error_t err = SB_SUCCESS;
 
+    // Indicate that this method's runtime should not depend on
+    // the value of info
+    sb_poison_input(info, info_len);
+
     // Nullify the context and output.
     SB_NULLIFY(ctx);
     SB_NULLIFY(private);
@@ -1417,6 +1422,10 @@ sb_error_t sb_sw_invert_private_key(sb_sw_context_t ctx[static const 1],
                                     sb_data_endian_t const e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // Indicate that this method's runtime should not depend on
+    // the value of private
+    sb_poison_input(private, sizeof(sb_sw_private_t));
 
     // Nullify the context and output.
     SB_NULLIFY(ctx);
@@ -1497,6 +1506,10 @@ sb_error_t sb_sw_compute_public_key_start
      const sb_data_endian_t e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // Indicate that this method's runtime should not depend on
+    // the value of private
+    sb_poison_input(private, sizeof(sb_sw_private_t));
 
     // Nullify the context.
     SB_NULLIFY(ctx);
@@ -1608,6 +1621,10 @@ sb_error_t sb_sw_compute_public_key(sb_sw_context_t ctx[static const 1],
 {
     sb_error_t err = SB_SUCCESS;
 
+    // Indicate that this method's runtime should not depend on
+    // the value of private
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+
     err |= sb_sw_compute_public_key_start(ctx, private, drbg, curve, e);
     SB_RETURN_ERRORS(err, ctx);
 
@@ -1628,6 +1645,10 @@ sb_error_t sb_sw_valid_private_key(sb_sw_context_t ctx[static const 1],
                                    const sb_data_endian_t e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // Indicate that this method's runtime should not depend on
+    // the value of private
+    sb_poison_input(private, sizeof(sb_sw_private_t));
 
     SB_NULLIFY(ctx);
 
@@ -1650,6 +1671,10 @@ sb_error_t sb_sw_valid_public_key(sb_sw_context_t ctx[static const 1],
                                   const sb_data_endian_t e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // Indicate that this method's runtime should not depend on
+    // the value of public
+    sb_poison_input(public, sizeof(sb_sw_public_t));
 
     SB_NULLIFY(ctx);
 
@@ -1674,6 +1699,10 @@ sb_error_t sb_sw_compress_public_key(sb_sw_context_t ctx[static const 1],
                                      sb_data_endian_t e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // Indicate that this method's runtime should not depend on
+    // the value of public
+    sb_poison_input(public, sizeof(sb_sw_public_t));
 
     // Nullify the context and output.
     SB_NULLIFY(ctx);
@@ -1711,6 +1740,11 @@ sb_error_t sb_sw_decompress_public_key
      sb_data_endian_t e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // Indicate that this method's runtime should not depend on
+    // the value of compressed and sign
+    sb_poison_input(compressed, sizeof(sb_sw_compressed_t));
+    sb_poison_input(&sign, sizeof(sign));
 
     // Nullify the context and output.
     SB_NULLIFY(ctx);
@@ -1803,6 +1837,11 @@ sb_error_t sb_sw_shared_secret_start
 {
     sb_error_t err = SB_SUCCESS;
 
+    // Indicate that this method's runtime should not depend on
+    // the value of private or public
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+    sb_poison_input(public, sizeof(sb_sw_public_t));
+
     // Nullify the context.
     SB_NULLIFY(ctx);
 
@@ -1877,6 +1916,11 @@ sb_error_t sb_sw_shared_secret(sb_sw_context_t ctx[static const 1],
 {
     sb_error_t err = SB_SUCCESS;
 
+    // Indicate that this method's runtime should not depend on
+    // the value of private or public
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+    sb_poison_input(public, sizeof(sb_sw_public_t));
+
     err |= sb_sw_shared_secret_start(ctx, private, public, drbg, curve, e);
     SB_RETURN_ERRORS(err, ctx);
 
@@ -1901,6 +1945,11 @@ sb_error_t sb_sw_point_multiply_start
      const sb_data_endian_t e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // Indicate that this method's runtime should not depend on
+    // the value of private or public
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+    sb_poison_input(public, sizeof(sb_sw_public_t));
 
     // Nullify the context.
     SB_NULLIFY(ctx);
@@ -1976,6 +2025,11 @@ sb_error_t sb_sw_point_multiply(sb_sw_context_t ctx[static const 1],
 {
     sb_error_t err = SB_SUCCESS;
 
+    // Indicate that this method's runtime should not depend on
+    // the value of private or public
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+    sb_poison_input(public, sizeof(sb_sw_public_t));
+
     err |= sb_sw_point_multiply_start(ctx, private, public, drbg, curve, e);
     SB_RETURN_ERRORS(err, ctx);
 
@@ -2002,6 +2056,11 @@ static sb_error_t sb_sw_sign_message_digest_shared_start
      const sb_data_endian_t e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // Indicate that this method's runtime should not depend on
+    // the value of private or message
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+    sb_poison_input(message, sizeof(sb_sw_message_digest_t));
 
     // Validate the private scalar and message.
 
@@ -2038,6 +2097,14 @@ sb_error_t sb_sw_sign_message_digest_with_k_beware_of_the_leopard
      const sb_data_endian_t e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // TODO: If this method causes an error we can remove the timing check. 
+    // Timing checks are included in this method for extra coverage.
+    // Indicate that this method's runtime should not depend on
+    // the value of private, message, or k
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+    sb_poison_input(message, sizeof(sb_sw_message_digest_t));
+    sb_poison_input(k, sizeof(sb_sw_private_t));
 
     // Nullify the context and output.
     SB_NULLIFY(ctx);
@@ -2092,6 +2159,11 @@ sb_error_t sb_sw_sign_message_digest_start
      const sb_data_endian_t e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // Indicate that this method's runtime should not depend on
+    // the value of private or message
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+    sb_poison_input(message, sizeof(sb_sw_message_digest_t));
 
     // Nullify the context.
     SB_NULLIFY(ctx);
@@ -2226,6 +2298,10 @@ sb_error_t sb_sw_sign_message_sha256_start
      const sb_sw_curve_id_t curve,
      const sb_data_endian_t e)
 {
+    // Indicate that this method's runtime should not depend on
+    // the value of private
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+
     sb_sha256_finish_to_buffer(sha);
 
     // This egregious cast works because sb_sw_message_digest_t is just a struct
@@ -2295,6 +2371,11 @@ sb_error_t sb_sw_sign_message_digest
 {
     sb_error_t err = SB_SUCCESS;
 
+    // Indicate that this method's runtime should not depend on
+    // the value of private or message
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+    sb_poison_input(message, sizeof(sb_sw_message_digest_t));
+
     err |= sb_sw_sign_message_digest_start(ctx, private, message,
                                            provided_drbg, curve, e);
     SB_RETURN_ERRORS(err, ctx);
@@ -2321,6 +2402,11 @@ sb_error_t sb_sw_sign_message_sha256
      const sb_sw_curve_id_t curve,
      const sb_data_endian_t e)
 {
+    // Indicate that this method's runtime should not depend on
+    // the value of private or input
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+    sb_poison_input(input, input_len);
+    
     // Compute the message digest and provide it as output.
     sb_sha256_message(&ctx->param_gen.sha, digest->bytes, input, input_len);
 
@@ -2338,6 +2424,11 @@ sb_error_t sb_sw_composite_sign_wrap_message_digest
      sb_data_endian_t const e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // Indicate that this method's runtime should not depend on
+    // the value of message or private
+    sb_poison_input(message, sizeof(sb_sw_message_digest_t));
+    sb_poison_input(private, sizeof(sb_sw_private_t));
 
     // Nullify the context and output.
     SB_NULLIFY(ctx);
@@ -2431,6 +2522,11 @@ sb_error_t sb_sw_composite_sign_unwrap_signature
 {
     sb_error_t err = SB_SUCCESS;
 
+    // Indicate that this method's runtime should not depend on
+    // the value of signature or private
+    sb_poison_input(signature, sizeof(sb_sw_signature_t));
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+
     // Nullify the context
     SB_NULLIFY(ctx);
     SB_NULLIFY(unwrapped);
@@ -2483,6 +2579,12 @@ sb_error_t sb_sw_verify_signature_start
 {
     sb_error_t err = SB_SUCCESS;
 
+    // Indicate that this method's runtime should not depend on
+    // the value of signature, public, or message
+    sb_poison_input(signature, sizeof(sb_sw_signature_t));
+    sb_poison_input(public, sizeof(sb_sw_public_t));
+    sb_poison_input(message, sizeof(sb_sw_message_digest_t));
+
     // Nullify the context.
     SB_NULLIFY(ctx);
 
@@ -2529,6 +2631,11 @@ sb_error_t sb_sw_verify_signature_sha256_start
      const sb_sw_curve_id_t curve,
      const sb_data_endian_t e)
 {
+    // Indicate that this method's runtime should not depend on
+    // the value of signature or public
+    sb_poison_input(signature, sizeof(sb_sw_signature_t));
+    sb_poison_input(public, sizeof(sb_sw_public_t));
+
     sb_sha256_finish_to_buffer(sha);
 
     // This egregious cast works because sb_sw_message_digest_t is just a struct
@@ -2588,6 +2695,12 @@ sb_error_t sb_sw_verify_signature(sb_sw_context_t ctx[static const 1],
 {
     sb_error_t err = SB_SUCCESS;
 
+    // Indicate that this method's runtime should not depend on
+    // the value of signature, public, or message
+    sb_poison_input(signature, sizeof(sb_sw_signature_t));
+    sb_poison_input(public, sizeof(sb_sw_public_t));
+    sb_poison_input(message, sizeof(sb_sw_message_digest_t));
+
     err |= sb_sw_verify_signature_start(ctx, signature, public, message,
                                         drbg, curve, e);
     SB_RETURN_ERRORS(err, ctx);
@@ -2614,6 +2727,12 @@ sb_error_t sb_sw_verify_signature_sha256
      const sb_sw_curve_id_t curve,
      const sb_data_endian_t e)
 {
+    // Indicate that this method's runtime should not depend on
+    // the value of signature, public, or input
+    sb_poison_input(signature, sizeof(sb_sw_signature_t));
+    sb_poison_input(public, sizeof(sb_sw_public_t));
+    sb_poison_input(input, input_len);
+
     // Compute the message digest and provide it as output.
     sb_sha256_message(&ctx->param_gen.sha, digest->bytes, input, input_len);
 

--- a/src/sb_sw_lib.c
+++ b/src/sb_sw_lib.c
@@ -47,6 +47,7 @@
 #include "sb_hkdf.h"
 #include "sb_error.h"
 #include "sb_test_cavp.h"
+#include "sb_time.h"
 
 #include <stddef.h>
 #include <string.h>
@@ -945,7 +946,7 @@ sb_sw_point_validate(sb_sw_context_t c[static const 1],
     r &= !sb_fe_equal(&MULT_POINT(c)->y, &SB_FE_ZERO);
 
     // 5.6.2.3.4 step 2: unreduced points are not valid.
-    r &= (sb_fe_lt(&MULT_POINT(c)->x, &s->p->p) &&
+    r &= (sb_fe_lt(&MULT_POINT(c)->x, &s->p->p) &
           sb_fe_lt(&MULT_POINT(c)->y, &s->p->p));
 
     // Valid Y values are now ensured to be quasi-reduced. Invalid Y values
@@ -1388,6 +1389,10 @@ sb_error_t sb_sw_hkdf_expand_private_key(sb_sw_context_t ctx[static const 1],
 {
     sb_error_t err = SB_SUCCESS;
 
+    // Indicate that this method's runtime should not depend on
+    // the value of info
+    sb_poison_input(info, info_len);
+
     // Nullify the context and output.
     SB_NULLIFY(ctx);
     SB_NULLIFY(private);
@@ -1448,6 +1453,10 @@ sb_error_t sb_sw_invert_private_key(sb_sw_context_t ctx[static const 1],
                                     sb_data_endian_t const e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // Indicate that this method's runtime should not depend on
+    // the value of private
+    sb_poison_input(private, sizeof(sb_sw_private_t));
 
     // Nullify the context and output.
     SB_NULLIFY(ctx);
@@ -1528,6 +1537,10 @@ sb_error_t sb_sw_compute_public_key_start
      const sb_data_endian_t e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // Indicate that this method's runtime should not depend on
+    // the value of private
+    sb_poison_input(private, sizeof(sb_sw_private_t));
 
     // Nullify the context.
     SB_NULLIFY(ctx);
@@ -1639,6 +1652,10 @@ sb_error_t sb_sw_compute_public_key(sb_sw_context_t ctx[static const 1],
 {
     sb_error_t err = SB_SUCCESS;
 
+    // Indicate that this method's runtime should not depend on
+    // the value of private
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+
     err |= sb_sw_compute_public_key_start(ctx, private, drbg, curve, e);
     SB_RETURN_ERRORS(err, ctx);
 
@@ -1659,6 +1676,10 @@ sb_error_t sb_sw_valid_private_key(sb_sw_context_t ctx[static const 1],
                                    const sb_data_endian_t e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // Indicate that this method's runtime should not depend on
+    // the value of private
+    sb_poison_input(private, sizeof(sb_sw_private_t));
 
     SB_NULLIFY(ctx);
 
@@ -1681,6 +1702,10 @@ sb_error_t sb_sw_valid_public_key(sb_sw_context_t ctx[static const 1],
                                   const sb_data_endian_t e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // Indicate that this method's runtime should not depend on
+    // the value of public
+    sb_poison_input(public, sizeof(sb_sw_public_t));
 
     SB_NULLIFY(ctx);
 
@@ -1705,6 +1730,10 @@ sb_error_t sb_sw_compress_public_key(sb_sw_context_t ctx[static const 1],
                                      sb_data_endian_t e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // Indicate that this method's runtime should not depend on
+    // the value of public
+    sb_poison_input(public, sizeof(sb_sw_public_t));
 
     // Nullify the context and output.
     SB_NULLIFY(ctx);
@@ -1742,6 +1771,11 @@ sb_error_t sb_sw_decompress_public_key
      sb_data_endian_t e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // Indicate that this method's runtime should not depend on
+    // the value of compressed and sign
+    sb_poison_input(compressed, sizeof(sb_sw_compressed_t));
+    sb_poison_input(&sign, sizeof(sign));
 
     // Nullify the context and output.
     SB_NULLIFY(ctx);
@@ -1837,6 +1871,11 @@ sb_error_t sb_sw_shared_secret_start
 {
     sb_error_t err = SB_SUCCESS;
 
+    // Indicate that this method's runtime should not depend on
+    // the value of private or public
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+    sb_poison_input(public, sizeof(sb_sw_public_t));
+
     // Nullify the context.
     SB_NULLIFY(ctx);
 
@@ -1913,6 +1952,11 @@ sb_error_t sb_sw_shared_secret(sb_sw_context_t ctx[static const 1],
 {
     sb_error_t err = SB_SUCCESS;
 
+    // Indicate that this method's runtime should not depend on
+    // the value of private or public
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+    sb_poison_input(public, sizeof(sb_sw_public_t));
+
     err |= sb_sw_shared_secret_start(ctx, private, public, drbg, curve, e);
     SB_RETURN_ERRORS(err, ctx);
 
@@ -1937,6 +1981,11 @@ sb_error_t sb_sw_point_multiply_start
      const sb_data_endian_t e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // Indicate that this method's runtime should not depend on
+    // the value of private or public
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+    sb_poison_input(public, sizeof(sb_sw_public_t));
 
     // Nullify the context.
     SB_NULLIFY(ctx);
@@ -2017,6 +2066,11 @@ sb_error_t sb_sw_point_multiply(sb_sw_context_t ctx[static const 1],
 {
     sb_error_t err = SB_SUCCESS;
 
+    // Indicate that this method's runtime should not depend on
+    // the value of private or public
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+    sb_poison_input(public, sizeof(sb_sw_public_t));
+
     err |= sb_sw_point_multiply_start(ctx, private, public, drbg, curve, e);
     SB_RETURN_ERRORS(err, ctx);
 
@@ -2043,6 +2097,11 @@ static sb_error_t sb_sw_sign_message_digest_shared_start
      const sb_data_endian_t e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // Indicate that this method's runtime should not depend on
+    // the value of private or message
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+    sb_poison_input(message, sizeof(sb_sw_message_digest_t));
 
     // Validate the private scalar and message.
 
@@ -2079,6 +2138,14 @@ sb_error_t sb_sw_sign_message_digest_with_k_beware_of_the_leopard
      const sb_data_endian_t e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // TODO: If this method causes an error we can remove the timing check. 
+    // Timing checks are included in this method for extra coverage.
+    // Indicate that this method's runtime should not depend on
+    // the value of private, message, or k
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+    sb_poison_input(message, sizeof(sb_sw_message_digest_t));
+    sb_poison_input(k, sizeof(sb_sw_private_t));
 
     // Nullify the context and output.
     SB_NULLIFY(ctx);
@@ -2133,6 +2200,11 @@ sb_error_t sb_sw_sign_message_digest_start
      const sb_data_endian_t e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // Indicate that this method's runtime should not depend on
+    // the value of private or message
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+    sb_poison_input(message, sizeof(sb_sw_message_digest_t));
 
     // Nullify the context.
     SB_NULLIFY(ctx);
@@ -2267,6 +2339,10 @@ sb_error_t sb_sw_sign_message_sha256_start
      const sb_sw_curve_id_t curve,
      const sb_data_endian_t e)
 {
+    // Indicate that this method's runtime should not depend on
+    // the value of private
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+
     sb_sha256_finish_to_buffer(sha);
 
     // This egregious cast works because sb_sw_message_digest_t is just a struct
@@ -2336,6 +2412,11 @@ sb_error_t sb_sw_sign_message_digest
 {
     sb_error_t err = SB_SUCCESS;
 
+    // Indicate that this method's runtime should not depend on
+    // the value of private or message
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+    sb_poison_input(message, sizeof(sb_sw_message_digest_t));
+
     err |= sb_sw_sign_message_digest_start(ctx, private, message,
                                            provided_drbg, curve, e);
     SB_RETURN_ERRORS(err, ctx);
@@ -2362,6 +2443,11 @@ sb_error_t sb_sw_sign_message_sha256
      const sb_sw_curve_id_t curve,
      const sb_data_endian_t e)
 {
+    // Indicate that this method's runtime should not depend on
+    // the value of private or input
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+    sb_poison_input(input, input_len);
+    
     // Compute the message digest and provide it as output.
     sb_sha256_message(&ctx->param_gen.sha, digest->bytes, input, input_len);
 
@@ -2379,6 +2465,11 @@ sb_error_t sb_sw_composite_sign_wrap_message_digest
      sb_data_endian_t const e)
 {
     sb_error_t err = SB_SUCCESS;
+
+    // Indicate that this method's runtime should not depend on
+    // the value of message or private
+    sb_poison_input(message, sizeof(sb_sw_message_digest_t));
+    sb_poison_input(private, sizeof(sb_sw_private_t));
 
     // Nullify the context and output.
     SB_NULLIFY(ctx);
@@ -2472,6 +2563,11 @@ sb_error_t sb_sw_composite_sign_unwrap_signature
 {
     sb_error_t err = SB_SUCCESS;
 
+    // Indicate that this method's runtime should not depend on
+    // the value of signature or private
+    sb_poison_input(signature, sizeof(sb_sw_signature_t));
+    sb_poison_input(private, sizeof(sb_sw_private_t));
+
     // Nullify the context
     SB_NULLIFY(ctx);
     SB_NULLIFY(unwrapped);
@@ -2524,6 +2620,12 @@ sb_error_t sb_sw_verify_signature_start
 {
     sb_error_t err = SB_SUCCESS;
 
+    // Indicate that this method's runtime should not depend on
+    // the value of signature, public, or message
+    sb_poison_input(signature, sizeof(sb_sw_signature_t));
+    sb_poison_input(public, sizeof(sb_sw_public_t));
+    sb_poison_input(message, sizeof(sb_sw_message_digest_t));
+
     // Nullify the context.
     SB_NULLIFY(ctx);
 
@@ -2570,6 +2672,11 @@ sb_error_t sb_sw_verify_signature_sha256_start
      const sb_sw_curve_id_t curve,
      const sb_data_endian_t e)
 {
+    // Indicate that this method's runtime should not depend on
+    // the value of signature or public
+    sb_poison_input(signature, sizeof(sb_sw_signature_t));
+    sb_poison_input(public, sizeof(sb_sw_public_t));
+
     sb_sha256_finish_to_buffer(sha);
 
     // This egregious cast works because sb_sw_message_digest_t is just a struct
@@ -2629,6 +2736,12 @@ sb_error_t sb_sw_verify_signature(sb_sw_context_t ctx[static const 1],
 {
     sb_error_t err = SB_SUCCESS;
 
+    // Indicate that this method's runtime should not depend on
+    // the value of signature, public, or message
+    sb_poison_input(signature, sizeof(sb_sw_signature_t));
+    sb_poison_input(public, sizeof(sb_sw_public_t));
+    sb_poison_input(message, sizeof(sb_sw_message_digest_t));
+
     err |= sb_sw_verify_signature_start(ctx, signature, public, message,
                                         drbg, curve, e);
     SB_RETURN_ERRORS(err, ctx);
@@ -2655,6 +2768,12 @@ sb_error_t sb_sw_verify_signature_sha256
      const sb_sw_curve_id_t curve,
      const sb_data_endian_t e)
 {
+    // Indicate that this method's runtime should not depend on
+    // the value of signature, public, or input
+    sb_poison_input(signature, sizeof(sb_sw_signature_t));
+    sb_poison_input(public, sizeof(sb_sw_public_t));
+    sb_poison_input(input, input_len);
+
     // Compute the message digest and provide it as output.
     sb_sha256_message(&ctx->param_gen.sha, digest->bytes, input, input_len);
 

--- a/src/sb_sw_lib_tests.c.h
+++ b/src/sb_sw_lib_tests.c.h
@@ -899,10 +899,10 @@ _Bool sb_test_p256_zero_x(void)
     SB_TEST_ASSERT_SUCCESS(sb_sw_decompress_public_key(&ct, &p_zero, &zero, 0, SB_SW_CURVE_P256, SB_DATA_ENDIAN_BIG));
     SB_TEST_ASSERT_SUCCESS(sb_sw_decompress_public_key(&ct, &p_zero_pos, &zero, 1, SB_SW_CURVE_P256, SB_DATA_ENDIAN_BIG));
 
-    SB_TEST_ASSERT(memcmp(p_zero.bytes, zero.bytes, SB_ELEM_BYTES) == 0);
+    SB_TEST_ASSERT_EQUAL(p_zero.bytes, zero.bytes, SB_ELEM_BYTES);
     SB_TEST_ASSERT((p_zero.bytes[2 * SB_ELEM_BYTES - 1] & 1) == 0);
 
-    SB_TEST_ASSERT(memcmp(p_zero_pos.bytes, zero.bytes, SB_ELEM_BYTES) == 0);
+    SB_TEST_ASSERT_EQUAL(p_zero_pos.bytes, zero.bytes, SB_ELEM_BYTES);
     SB_TEST_ASSERT((p_zero_pos.bytes[2 * SB_ELEM_BYTES - 1] & 1) == 1);
 
     _Bool sign;

--- a/src/sb_sw_lib_tests.c.h
+++ b/src/sb_sw_lib_tests.c.h
@@ -55,7 +55,7 @@ static const sb_byte_t NULL_ENTROPY[32] = { 0 };
         (drbg)->additional_input_required = 1; \
     } while (0)
 
-#define SB_TEST_RAND_COUNT 128
+#define SB_TEST_RAND_COUNT 32
 
 // De-incrementalized point multiplication wrapper for unit tests.
 static void
@@ -1363,7 +1363,7 @@ static size_t verify_recover_public_key(sb_sw_public_t keys[4],
     size_t i = 0;
 
     extract_sig_components(&m, sig, message, s, e);
-
+    sb_unpoison_output(&m, sizeof(m));
     if (sb_sw_point_decompress(&m, 0, s)) {
 
         pk_recovery(&m, s);
@@ -1387,7 +1387,7 @@ static size_t verify_recover_public_key(sb_sw_public_t keys[4],
     }
 
     extract_sig_components(&m, sig, message, s, e);
-
+    sb_unpoison_output(&m, sizeof(m));
     sb_fe_sub(C_T5(&m), &s->p->p, &s->n->p); // t5 = P - N
     if (sb_fe_lt(VERIFY_QR(&m), C_T5(&m)) |
         sb_fe_equal(VERIFY_QR(&m), C_T5(&m))) {
@@ -1859,43 +1859,42 @@ static _Bool sb_test_invalid_sig(const sb_byte_t invalid[static const SB_ELEM_BY
 }
 
 _Bool sb_test_sw_invalid_sig_p256(void) {
+    sb_sw_curve_id_t c = SB_SW_CURVE_P256;
+    sb_data_endian_t e = SB_DATA_ENDIAN_BIG;
     // Load up some buffers with the invalid signature values
     // 0 and N.
     sb_byte_t zeros[SB_ELEM_BYTES] = {0};
 
     sb_byte_t n[SB_ELEM_BYTES];
     const sb_sw_curve_t* s = NULL;
-    SB_TEST_ASSERT_SUCCESS(
-        sb_sw_curve_from_id(&s, SB_SW_CURVE_P256));
+    SB_TEST_ASSERT_SUCCESS(sb_sw_curve_from_id(&s, c));
 
-    sb_fe_to_bytes(n, &s->n->p, SB_DATA_ENDIAN_BIG);
+    sb_fe_to_bytes(n, &s->n->p, e);
 
-    return sb_test_invalid_sig(zeros,
-                               SB_SW_CURVE_P256, 
-                               SB_DATA_ENDIAN_BIG);
-    return sb_test_invalid_sig(n, 
-                               SB_SW_CURVE_P256,  
-                               SB_DATA_ENDIAN_BIG);
+    SB_TEST_ASSERT(sb_test_invalid_sig(zeros, c, e) == 1);
+    SB_TEST_ASSERT(sb_test_invalid_sig(n, c, e) == 1);
+
+    return 1;
 }
 
 _Bool sb_test_sw_invalid_sig_secp256k1(void) {
+    sb_sw_curve_id_t c = SB_SW_CURVE_SECP256K1;
+    sb_data_endian_t e = SB_DATA_ENDIAN_LITTLE;
+
     // Load up some buffers with the invalid signature values
     // 0 and N.
     sb_byte_t zeros[SB_ELEM_BYTES] = {0};
 
     sb_byte_t n[SB_ELEM_BYTES];
     const sb_sw_curve_t* s = NULL;
-    SB_TEST_ASSERT_SUCCESS(
-        sb_sw_curve_from_id(&s, SB_SW_CURVE_SECP256K1));
+    SB_TEST_ASSERT_SUCCESS(sb_sw_curve_from_id(&s, c));
 
-    sb_fe_to_bytes(n, &s->n->p, SB_DATA_ENDIAN_LITTLE);
+    sb_fe_to_bytes(n, &s->n->p, e);
 
-    return sb_test_invalid_sig(zeros,
-                               SB_SW_CURVE_SECP256K1, 
-                               SB_DATA_ENDIAN_LITTLE);
-    return sb_test_invalid_sig(n,
-                               SB_SW_CURVE_SECP256K1, 
-                               SB_DATA_ENDIAN_LITTLE);
+    SB_TEST_ASSERT(sb_test_invalid_sig(zeros, c, e) == 1);
+    SB_TEST_ASSERT(sb_test_invalid_sig(n, c, e) == 1);
+
+    return 1;
 }
 
 

--- a/src/sb_sw_lib_tests.c.h
+++ b/src/sb_sw_lib_tests.c.h
@@ -186,6 +186,29 @@ _Bool sb_test_ladder_simple(void)
     SB_TEST_ASSERT(test_ladder_simple(&SB_CURVE_P256.g_r, &SB_CURVE_P256));
     SB_TEST_ASSERT(test_ladder_simple(&SB_CURVE_P256.h_r, &SB_CURVE_P256));
     SB_TEST_ASSERT(test_ladder_simple(&SB_CURVE_P256.g_h_r, &SB_CURVE_P256));
+
+    // Testing for (0, sqrt(B))
+    for (sb_word_t sign = 0; sign <= 1; sign++) {
+        const sb_sw_curve_t* const s = &SB_CURVE_P256;
+        sb_sw_context_t m;
+        SB_NULLIFY(&m); // entire structure is now zeroed
+
+        SB_TEST_ASSERT(sb_sw_point_decompress(&m, sign, s));
+        // MULT_POINT(&m) now holds (0, sqrt(B))
+
+        sb_double_t z;
+        SB_NULLIFY(&z);
+        sb_fe_to_bytes(z.bytes + SB_ELEM_BYTES, MULT_POINT_Y(&m), SB_DATA_ENDIAN_BIG);
+        // z now holds (0, sqrt(B)) as a serialized point
+
+        sb_fe_pair_t zp;
+
+        zp.x = s->p->p;
+        sb_fe_mont_convert(&zp.y, &MULT_POINT(&m)->y, s->p);
+
+        SB_TEST_ASSERT(test_ladder_simple(&zp, &SB_CURVE_P256));
+    }
+
     SB_TEST_ASSERT(
         test_ladder_simple(&SB_CURVE_SECP256K1.g_r, &SB_CURVE_SECP256K1));
     SB_TEST_ASSERT(
@@ -277,8 +300,8 @@ _Bool sb_test_secp256k1_endomorphism(void)
     return 1;
 }
 
-// The following scalars cause exceptions in the ladder. Test that our
-// handling of these exceptions is valid.
+// The following scalars would cause exceptions in the ladder.
+// Test that our handling of these exceptions is valid.
 _Bool sb_test_exceptions(void)
 {
     sb_sw_context_t m;
@@ -288,46 +311,90 @@ _Bool sb_test_exceptions(void)
     // Exceptions produce P, not zero, due to ZVA countermeasures
 #define EX_ZERO(c) ((c).p->p)
 
-#define TEST_EX() do { \
+#define TEST_EX(kv, pv) do { \
+    *MULT_K(&m) = (kv); \
+    *MULT_POINT(&m) = (pv); \
     SB_TEST_ASSERT(!sb_sw_scalar_validate(MULT_K(&m), &SB_CURVE_P256)); \
     sb_sw_point_mult(&m, &SB_CURVE_P256); \
     SB_TEST_ASSERT(sb_fe_equal(C_X1(&m), &EX_ZERO(SB_CURVE_P256)) && \
            sb_fe_equal(C_Y1(&m), &EX_ZERO(SB_CURVE_P256))); \
 } while (0)
 
-#define TEST_NO_EX() do { \
+#define TEST_NO_EX(kv, pv) do { \
+    *MULT_K(&m) = (kv); \
+    *MULT_POINT(&m) = (pv); \
     SB_TEST_ASSERT(sb_sw_scalar_validate(MULT_K(&m), &SB_CURVE_P256)); \
     sb_sw_point_mult(&m, &SB_CURVE_P256); \
     SB_TEST_ASSERT(!(sb_fe_equal(C_X1(&m), &EX_ZERO(SB_CURVE_P256)) && \
            sb_fe_equal(C_Y1(&m), &EX_ZERO(SB_CURVE_P256)))); \
 } while (0)
 
-    *MULT_POINT(&m) = SB_CURVE_P256.g_r;
+    sb_fe_t k;
+    const sb_fe_pair_t g = SB_CURVE_P256.g_r;
+
+    sb_fe_pair_t z_even, z_odd;
+
+    z_even.x = SB_CURVE_P256_P.p;
+    z_odd.x = SB_CURVE_P256_P.p;
+
+    *MULT_POINT_X(&m) = SB_FE_ZERO;
+    SB_TEST_ASSERT(sb_sw_point_decompress(&m, 0, &SB_CURVE_P256));
+    sb_fe_mont_convert(&z_even.y, MULT_POINT_Y(&m), &SB_CURVE_P256_P);
+
+    *MULT_POINT_X(&m) = SB_FE_ZERO;
+    SB_TEST_ASSERT(sb_sw_point_decompress(&m, 1, &SB_CURVE_P256));
+    sb_fe_mont_convert(&z_odd.y, MULT_POINT_Y(&m), &SB_CURVE_P256_P);
 
     // This is not an exception, strictly speaking.
     // k = 0
-    *MULT_K(&m) = SB_CURVE_P256.n->p;
-    TEST_EX();
+    TEST_EX(SB_CURVE_P256.n->p, g);
+    TEST_EX(SB_CURVE_P256.n->p, z_even);
+    TEST_EX(SB_CURVE_P256.n->p, z_odd);
 
     // k = 1
-    *MULT_K(&m) = SB_FE_ONE;
-    TEST_NO_EX();
+    TEST_NO_EX(SB_FE_ONE, g);
+    TEST_NO_EX(SB_FE_ONE, z_even);
+    TEST_NO_EX(SB_FE_ONE, z_odd);
 
     // k = -1
-    *MULT_K(&m) = SB_CURVE_P256.n->p;
-    sb_fe_mod_sub(MULT_K(&m), MULT_K(&m), &SB_FE_ONE, SB_CURVE_P256.n);
-    TEST_NO_EX();
+    k = SB_CURVE_P256.n->p;
+    sb_fe_mod_sub(&k, &k, &SB_FE_ONE, SB_CURVE_P256.n);
+    TEST_NO_EX(k, g);
+    TEST_NO_EX(k, z_even);
+    TEST_NO_EX(k, z_odd);
 
     // k = -2
-    *MULT_K(&m) = SB_CURVE_P256.n->p;
-    sb_fe_mod_sub(MULT_K(&m), MULT_K(&m), &SB_FE_ONE, SB_CURVE_P256.n);
-    sb_fe_mod_sub(MULT_K(&m), MULT_K(&m), &SB_FE_ONE, SB_CURVE_P256.n);
-    TEST_NO_EX();
+    k = SB_CURVE_P256.n->p;
+    sb_fe_mod_sub(&k, &k, &SB_FE_ONE, SB_CURVE_P256.n);
+    sb_fe_mod_double(&k, &k, SB_CURVE_P256.n);
+    TEST_NO_EX(k, g);
+    TEST_NO_EX(k, z_even);
+    TEST_NO_EX(k, z_odd);
 
     // k = 2
-    *MULT_K(&m) = SB_FE_ONE;
-    sb_fe_mod_add(MULT_K(&m), MULT_K(&m), &SB_FE_ONE, SB_CURVE_P256.n);
-    TEST_NO_EX();
+    k = SB_FE_ONE;
+    sb_fe_mod_double(&k, &k, SB_CURVE_P256.n);
+    TEST_NO_EX(k, g);
+    TEST_NO_EX(k, z_even);
+    TEST_NO_EX(k, z_odd);
+
+    // k = -4 causes exceptions for (0, ±√B)
+    k = SB_CURVE_P256.n->p;
+    sb_fe_mod_sub(&k, &k, &SB_FE_ONE, SB_CURVE_P256.n);
+    sb_fe_mod_double(&k, &k, SB_CURVE_P256.n);
+    sb_fe_mod_double(&k, &k, SB_CURVE_P256.n);
+    TEST_NO_EX(k, g);
+    TEST_NO_EX(k, z_even);
+    TEST_NO_EX(k, z_odd);
+
+    // k = 4 causes exceptions for (0, ±√B)
+    k = SB_FE_ONE;
+    sb_fe_mod_double(&k, &k, SB_CURVE_P256.n);
+    sb_fe_mod_double(&k, &k, SB_CURVE_P256.n);
+    TEST_NO_EX(k, g);
+    TEST_NO_EX(k, z_even);
+    TEST_NO_EX(k, z_odd);
+
     return 1;
 }
 
@@ -373,6 +440,67 @@ _Bool sb_test_sw_h(void)
 {
     SB_TEST_ASSERT(test_h(&SB_CURVE_P256));
     SB_TEST_ASSERT(test_h(&SB_CURVE_SECP256K1));
+
+    return 1;
+}
+
+// Test that the special value dz_r is computed correctly.
+_Bool sb_test_p256_dz(void)
+{
+    const sb_sw_curve_t* const s = &SB_CURVE_P256;
+    sb_sw_context_t m;
+    SB_NULLIFY(&m); // entire structure is now zeroed
+
+    SB_TEST_ASSERT(sb_sw_point_decompress(&m, 0, s));
+    // MULT_POINT(&m) now holds (0, sqrt(B))
+
+    sb_double_t z;
+    SB_NULLIFY(&z);
+    sb_fe_to_bytes(z.bytes + SB_ELEM_BYTES, MULT_POINT_Y(&m), SB_DATA_ENDIAN_BIG);
+    // z now holds (0, sqrt(B)) as a serialized point
+
+    *C_X2(&m) = s->p->p;
+    sb_fe_mont_convert(C_Y2(&m), &MULT_POINT(&m)->y, s->p);
+
+    sb_sw_point_initial_double(&m, s);
+    // (x2, y2) now holds 2*P with Z in t5
+
+    sb_fe_mod_inv_r(C_T5(&m), C_T6(&m), C_T7(&m), s->p);
+    // t5 now holds Z^-1
+
+    sb_fe_mont_square(C_T6(&m), C_T5(&m), s->p); // t6 = Z^-2
+    sb_fe_mont_mult(C_T7(&m), C_T5(&m), C_T6(&m), s->p); // t7 = Z^-3
+
+    sb_fe_mont_mult(C_X1(&m), C_X2(&m), C_T6(&m), s->p); // x1 = x2 * Z^-2
+    sb_fe_mont_mult(C_Y1(&m), C_Y2(&m), C_T7(&m), s->p); // y1 = y2 * Z^-3
+
+    // Verify dz_r
+    SB_TEST_ASSERT_EQUAL(*C_X1(&m), s->dz_r.x);
+    SB_TEST_ASSERT_EQUAL(*C_Y1(&m), s->dz_r.y);
+
+    // Montgomery reduce to obtain output point
+    sb_fe_mont_reduce(MULT_POINT_X(&m), C_X1(&m), s->p);
+    sb_fe_mont_reduce(MULT_POINT_Y(&m), C_Y1(&m), s->p);
+
+    sb_double_t p;
+    sb_fe_to_bytes(p.bytes, MULT_POINT_X(&m), SB_DATA_ENDIAN_BIG);
+    sb_fe_to_bytes(p.bytes + SB_ELEM_BYTES, MULT_POINT_Y(&m), SB_DATA_ENDIAN_BIG);
+
+    // p now holds 2 * (0, sqrt(B))
+
+    sb_single_t k, k_inv;
+    // t5 = 2
+    *C_T5(&m) = (sb_fe_t) SB_FE_CONST_QR(0, 0, 0, 2, &SB_CURVE_P256_P);
+    sb_fe_to_bytes(k.bytes, C_T5(&m), SB_DATA_ENDIAN_BIG);
+
+    SB_TEST_ASSERT_SUCCESS(sb_sw_invert_private_key(&m, &k_inv, &k, NULL, SB_SW_CURVE_P256, SB_DATA_ENDIAN_BIG));
+
+    // k_inv = 2^-1 mod p
+
+    sb_double_t o;
+
+    SB_TEST_ASSERT_SUCCESS(sb_sw_point_multiply(&m, &o, &k_inv, &p, NULL, SB_SW_CURVE_P256, SB_DATA_ENDIAN_BIG));
+    SB_TEST_ASSERT_EQUAL(o, z);
 
     return 1;
 }
@@ -751,6 +879,63 @@ _Bool sb_test_shared_secret_cavp_1(void)
     return 1;
 }
 
+// Test that the point (0, ±√𝐵) is handled correctly in shared secrets.
+_Bool sb_test_p256_zero_x(void)
+{
+    sb_sw_context_t ct;
+
+    const sb_sw_compressed_t zero = { .bytes = { 0 } };
+
+    sb_sw_public_t p_zero;
+    sb_sw_public_t p_zero_pos;
+
+    sb_sw_public_t sh1, sh2;
+    sb_sw_private_t k, k_inv;
+
+    sb_hmac_drbg_state_t drbg;
+
+    NULL_DRBG_INIT(&drbg);
+
+    SB_TEST_ASSERT_SUCCESS(sb_sw_decompress_public_key(&ct, &p_zero, &zero, 0, SB_SW_CURVE_P256, SB_DATA_ENDIAN_BIG));
+    SB_TEST_ASSERT_SUCCESS(sb_sw_decompress_public_key(&ct, &p_zero_pos, &zero, 1, SB_SW_CURVE_P256, SB_DATA_ENDIAN_BIG));
+
+    SB_TEST_ASSERT(memcmp(p_zero.bytes, zero.bytes, SB_ELEM_BYTES) == 0);
+    SB_TEST_ASSERT((p_zero.bytes[2 * SB_ELEM_BYTES - 1] & 1) == 0);
+
+    SB_TEST_ASSERT(memcmp(p_zero_pos.bytes, zero.bytes, SB_ELEM_BYTES) == 0);
+    SB_TEST_ASSERT((p_zero_pos.bytes[2 * SB_ELEM_BYTES - 1] & 1) == 1);
+
+    _Bool sign;
+    sb_sw_compressed_t zero_comp;
+
+    SB_TEST_ASSERT_SUCCESS(sb_sw_compress_public_key(&ct, &zero_comp, &sign, &p_zero, SB_SW_CURVE_P256, SB_DATA_ENDIAN_BIG));
+    SB_TEST_ASSERT_EQUAL(zero, zero_comp);
+    SB_TEST_ASSERT(sign == 0);
+
+    SB_TEST_ASSERT_SUCCESS(sb_sw_compress_public_key(&ct, &zero_comp, &sign, &p_zero_pos, SB_SW_CURVE_P256, SB_DATA_ENDIAN_BIG));
+    SB_TEST_ASSERT_EQUAL(zero, zero_comp);
+    SB_TEST_ASSERT(sign == 1);
+
+    SB_TEST_ASSERT_SUCCESS(sb_sw_generate_private_key(&ct, &k, &drbg, SB_SW_CURVE_P256, SB_DATA_ENDIAN_BIG));
+    SB_TEST_ASSERT_SUCCESS(sb_sw_invert_private_key(&ct, &k_inv, &k, NULL, SB_SW_CURVE_P256, SB_DATA_ENDIAN_BIG));
+
+    SB_TEST_ASSERT_SUCCESS(sb_sw_point_multiply(&ct, &sh1, &k, &p_zero, NULL, SB_SW_CURVE_P256, SB_DATA_ENDIAN_BIG));
+    SB_TEST_ASSERT_NOT_EQUAL(p_zero, sh1);
+
+    SB_TEST_ASSERT_SUCCESS(sb_sw_point_multiply(&ct, &sh2, &k_inv, &sh1, NULL, SB_SW_CURVE_P256, SB_DATA_ENDIAN_BIG));
+    SB_TEST_ASSERT_EQUAL(p_zero, sh2);
+
+    SB_TEST_ASSERT_SUCCESS(sb_sw_generate_private_key(&ct, &k, &drbg, SB_SW_CURVE_P256, SB_DATA_ENDIAN_BIG));
+    SB_TEST_ASSERT_SUCCESS(sb_sw_invert_private_key(&ct, &k_inv, &k, NULL, SB_SW_CURVE_P256, SB_DATA_ENDIAN_BIG));
+
+    SB_TEST_ASSERT_SUCCESS(sb_sw_point_multiply(&ct, &sh1, &k, &p_zero_pos, NULL, SB_SW_CURVE_P256, SB_DATA_ENDIAN_BIG));
+    SB_TEST_ASSERT_NOT_EQUAL(p_zero_pos, sh1);
+
+    SB_TEST_ASSERT_SUCCESS(sb_sw_point_multiply(&ct, &sh2, &k_inv, &sh1, NULL, SB_SW_CURVE_P256, SB_DATA_ENDIAN_BIG));
+    SB_TEST_ASSERT_EQUAL(p_zero_pos, sh2);
+
+    return 1;
+}
 
 // Created for use in sb_test_shared_secret_secp256k1.
 // Also used in sb_test_sw_invalid_scalar as a valid public key for
@@ -1382,7 +1567,7 @@ _Bool sb_test_pk_recovery(void)
     SB_TEST_ASSERT(verify_recover_public_key(recovered, &TEST_SIG,
                                              &TEST_MESSAGE, &SB_CURVE_P256,
                                              SB_DATA_ENDIAN_BIG) == 2);
-    SB_TEST_ASSERT_EQUAL(recovered[1].bytes, TEST_PUB_2);
+    SB_TEST_ASSERT_EQUAL(recovered[0].bytes, TEST_PUB_2);
     return 1;
 }
 
@@ -1394,7 +1579,7 @@ _Bool sb_test_pk_recovery_james(void)
     SB_TEST_ASSERT(verify_recover_public_key(recovered, &JAMES_SIG,
                                              &JAMES_MESSAGE, &SB_CURVE_P256,
                                              SB_DATA_ENDIAN_BIG) == 2);
-    SB_TEST_ASSERT_EQUAL(recovered[0].bytes, JAMES_PUB);
+    SB_TEST_ASSERT_EQUAL(recovered[1].bytes, JAMES_PUB);
     SB_TEST_ASSERT(verify_recover_public_key(recovered, &JAMES_SIG_2,
                                              &JAMES_MESSAGE_2, &SB_CURVE_P256,
                                              SB_DATA_ENDIAN_BIG) == 2);
@@ -1917,6 +2102,9 @@ static _Bool sb_test_decompress_iter_c(const sb_sw_curve_id_t c,
         SB_TEST_ASSERT_SUCCESS(sb_sw_compress_public_key(&ct, &x, &sign, &p,
                                                          c,
                                                          e));
+                                              
+        // Verify that the low bit matches the produced sign.
+        SB_TEST_ASSERT((p.bytes[e == SB_DATA_ENDIAN_BIG ? 2 * SB_ELEM_BYTES - 1 : SB_ELEM_BYTES] & 1) == sign);
         SB_TEST_ASSERT_SUCCESS(sb_sw_decompress_public_key(&ct, &p2, &x,
                                                            sign, c,
                                                            e));

--- a/src/sb_sw_lib_tests.c.h
+++ b/src/sb_sw_lib_tests.c.h
@@ -566,7 +566,7 @@ static _Bool test_sw_point_mult_add(const sb_fe_t* const ka,
     sb_fe_mont_mult(C_X2(&q), C_T6(&q), &pabc.x, s->p); // x2 = x * Z^2
     sb_fe_mont_mult(C_Y2(&q), C_T7(&q), &pabc.y, s->p); // y2 = y * Z^3
     SB_TEST_ASSERT(
-        sb_fe_equal(C_X1(&q), C_X2(&q)) && sb_fe_equal(C_Y1(&q), C_Y2(&q)));
+        sb_fe_equal(C_X1(&q), C_X2(&q)) & sb_fe_equal(C_Y1(&q), C_Y2(&q)));
     return 1;
 }
 
@@ -1363,8 +1363,7 @@ static size_t verify_recover_public_key(sb_sw_public_t keys[4],
     size_t i = 0;
 
     extract_sig_components(&m, sig, message, s, e);
-    sb_unpoison_output(&m, sizeof(m));
-    if (sb_sw_point_decompress(&m, 0, s)) {
+    SB_TEST_IF_POISON(sb_sw_point_decompress(&m, 0, s)) {
 
         pk_recovery(&m, s);
 
@@ -1387,10 +1386,9 @@ static size_t verify_recover_public_key(sb_sw_public_t keys[4],
     }
 
     extract_sig_components(&m, sig, message, s, e);
-    sb_unpoison_output(&m, sizeof(m));
     sb_fe_sub(C_T5(&m), &s->p->p, &s->n->p); // t5 = P - N
-    if (sb_fe_lt(VERIFY_QR(&m), C_T5(&m)) |
-        sb_fe_equal(VERIFY_QR(&m), C_T5(&m))) {
+    SB_TEST_IF_POISON(sb_fe_lt(VERIFY_QR(&m), C_T5(&m)) |
+                      sb_fe_equal(VERIFY_QR(&m), C_T5(&m))) {
         *C_T5(&m) = s->n->p; // t5 = N
         sb_fe_mod_reduce(C_T5(&m), s->p); // N is reduced mod P
         sb_fe_mod_reduce(MULT_POINT_X(&m), s->p); // likewise

--- a/src/sb_sw_lib_tests.c.h
+++ b/src/sb_sw_lib_tests.c.h
@@ -438,7 +438,7 @@ static _Bool test_sw_point_mult_add(const sb_fe_t* const ka,
     sb_fe_mont_mult(C_X2(&q), C_T6(&q), &pabc.x, s->p); // x2 = x * Z^2
     sb_fe_mont_mult(C_Y2(&q), C_T7(&q), &pabc.y, s->p); // y2 = y * Z^3
     SB_TEST_ASSERT(
-        sb_fe_equal(C_X1(&q), C_X2(&q)) && sb_fe_equal(C_Y1(&q), C_Y2(&q)));
+        sb_fe_equal(C_X1(&q), C_X2(&q)) & sb_fe_equal(C_Y1(&q), C_Y2(&q)));
     return 1;
 }
 
@@ -1178,8 +1178,7 @@ static size_t verify_recover_public_key(sb_sw_public_t keys[4],
     size_t i = 0;
 
     extract_sig_components(&m, sig, message, s, e);
-    sb_unpoison_output(&m, sizeof(m));
-    if (sb_sw_point_decompress(&m, 0, s)) {
+    SB_TEST_IF_POISON(sb_sw_point_decompress(&m, 0, s)) {
 
         pk_recovery(&m, s);
 
@@ -1202,10 +1201,9 @@ static size_t verify_recover_public_key(sb_sw_public_t keys[4],
     }
 
     extract_sig_components(&m, sig, message, s, e);
-    sb_unpoison_output(&m, sizeof(m));
     sb_fe_sub(C_T5(&m), &s->p->p, &s->n->p); // t5 = P - N
-    if (sb_fe_lt(VERIFY_QR(&m), C_T5(&m)) |
-        sb_fe_equal(VERIFY_QR(&m), C_T5(&m))) {
+    SB_TEST_IF_POISON(sb_fe_lt(VERIFY_QR(&m), C_T5(&m)) |
+                      sb_fe_equal(VERIFY_QR(&m), C_T5(&m))) {
         *C_T5(&m) = s->n->p; // t5 = N
         sb_fe_mod_reduce(C_T5(&m), s->p); // N is reduced mod P
         sb_fe_mod_reduce(MULT_POINT_X(&m), s->p); // likewise

--- a/src/sb_test.h
+++ b/src/sb_test.h
@@ -100,10 +100,14 @@ extern _Bool sb_test_assert_failed(const char* file, const char* line,
 
 /* For timing tests, to be used in test case situations where we know the input
  * is poison and it's still OK to use in a conditional expression */
+#if SB_TIME
 #define SB_TEST_IF_POISON(v) \
     for (_Bool tmp_ ## __LINE__ = (v); \
          sb_unpoison_output(&tmp_ ## __LINE__, sizeof(sb_word_t)), tmp_ ## __LINE__; \
          tmp_ ## __LINE__ = 0)
+#else
+#define SB_TEST_IF_POISON(v) if ((v))
+#endif
 
 #define SB_TEST_ASSERT(e) do { \
     SB_TEST_IF_POISON(!(e)) { \

--- a/src/sb_test.h
+++ b/src/sb_test.h
@@ -51,7 +51,9 @@
 #endif
 
 #include <assert.h>
-#define SB_ASSERT(e, s) assert((e) && (s)[0])
+#define SB_ASSERT(e, s) do { \
+    assert((e) && (s)[0]); \
+} while (0) 
 #else
 #define SB_ASSERT(e, s) do { } while (0)
 #endif
@@ -60,6 +62,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "sb_types.h"
+#include "sb_time.h"
 
 #ifndef SB_TEST_ITER_DEFAULT
 #define SB_TEST_ITER_DEFAULT 8192
@@ -84,8 +87,6 @@ extern _Bool sb_test_string_to_bytes(const sb_test_buf_t* string,
                                      size_t blen);
 extern void sb_test_buf_free(sb_test_buf_t* buf);
 
-extern void sb_test_progress(size_t count, _Bool final);
-
 #define SB_TEST_BYTES(in, out) \
     SB_TEST_ASSERT(sb_test_string_to_bytes((in), (out).bytes, sizeof(out)))
 
@@ -98,7 +99,9 @@ extern _Bool sb_test_assert_failed(const char* file, const char* line,
                                    const char* expression);
 
 #define SB_TEST_ASSERT(e) do { \
-    if (!(e)) { \
+    _Bool temp = e; \
+    sb_unpoison_output(&(temp), sizeof(temp)); \
+    if (!(temp)) { \
         return sb_test_assert_failed(__FILE__, SB_TEST_STRINGIFY(__LINE__), #e); \
     } \
 } while (0)
@@ -107,8 +110,23 @@ extern _Bool sb_test_assert_failed(const char* file, const char* line,
 #define SB_TEST_ASSERT_ERROR(e, ...) SB_TEST_ASSERT((e) == \
     SB_ERRORS(__VA_ARGS__))
 
+static inline uint8_t sb_test_ctc(uint8_t* restrict a, 
+                                  uint8_t* restrict b, 
+                                  size_t len)
+{
+    uint8_t r = 0;
+    
+    for (size_t i = 0; i < len; i++) {
+        r |= (a[i] ^ b[i]);
+    }
+
+    return ((r | (uint8_t) -r) >> 7) ^ 1;
+}
+
 #define SB_TEST_ASSERT_EQUAL_2(v, e1, e2, s) \
-    SB_TEST_ASSERT((memcmp(&(e1), &(e2), (s)) == 0) == (v))
+    do { \
+        SB_TEST_ASSERT((sb_test_ctc(&(e1), &(e2), (s))) == (v)); \
+    } while (0)
 
 #define SB_TEST_ASSERT_EQUAL_1(v, e1, e2, unused) \
     SB_TEST_ASSERT_EQUAL_2(v, e1, e2, sizeof(e2))

--- a/src/sb_test_list.h
+++ b/src/sb_test_list.h
@@ -54,6 +54,7 @@ SB_DEFINE_TEST(hkdf);
 // These tests are for general field operations
 // and can be found in sb_fe_tests.c.h
 SB_DEFINE_TEST(fe);
+SB_DEFINE_TEST(mod_double);
 SB_DEFINE_TEST(mont_mult);
 SB_DEFINE_TEST(mont_mult_overflow);
 SB_DEFINE_TEST(mod_expt_p);
@@ -69,6 +70,7 @@ SB_DEFINE_TEST(ladder_simple);
 SB_DEFINE_TEST(secp256k1_endomorphism);
 SB_DEFINE_TEST(exceptions);
 SB_DEFINE_TEST(sw_h);
+SB_DEFINE_TEST(p256_dz);
 SB_DEFINE_TEST(sw_point_mult_add);
 // Known answer tests for keygen, shared_secret, and sign/verify work as they
 // should.
@@ -79,6 +81,7 @@ SB_DEFINE_TEST(valid_private);
 SB_DEFINE_TEST(valid_public);
 SB_DEFINE_TEST(shared_secret);
 SB_DEFINE_TEST(shared_secret_cavp_1);
+SB_DEFINE_TEST(p256_zero_x);
 SB_DEFINE_TEST(shared_secret_secp256k1);
 SB_DEFINE_TEST(sign_rfc6979);
 SB_DEFINE_TEST(sign_rfc6979_sha256);

--- a/src/sb_time.h
+++ b/src/sb_time.h
@@ -43,7 +43,9 @@
 #ifndef SB_TIME_H
 #define SB_TIME_H
 
-#include "../valgrind/memcheck.h"
+#ifdef SB_TIME
+#include <valgrind/memcheck.h>
+#endif
 
 /** 
  * Poisons a memory region of len bytes, starting at addr, indicating that

--- a/src/sb_time.h
+++ b/src/sb_time.h
@@ -43,7 +43,7 @@
 #ifndef SB_TIME_H
 #define SB_TIME_H
 
-#ifdef SB_TIME
+#if SB_TIME
 #include <valgrind/memcheck.h>
 #endif
 
@@ -53,7 +53,7 @@
  * This function is used to mark all fields that contain or are derived from 
  * secret data.
  */
-#ifdef SB_TIME
+#if SB_TIME
 #define sb_poison_input(addr, len) VALGRIND_MAKE_MEM_UNDEFINED(addr, len)
 #else
 #define sb_poison_input(addr, len) do { /* Nothing */ } while (0)
@@ -65,7 +65,7 @@
  * indicate that we no do not make any timing guarantees on invalid data, or 
  * to prevent propagation of a poisoned state object to all of its output.
  */
-#ifdef SB_TIME
+#if SB_TIME
 #define sb_unpoison_output(addr, len) VALGRIND_MAKE_MEM_DEFINED(addr, len)
 #else
 #define sb_unpoison_output(addr, len) do { /* Nothing */ } while (0)

--- a/src/sb_time.h
+++ b/src/sb_time.h
@@ -1,4 +1,4 @@
-/** @file sb_time.ch
+/** @file sb_time.h
  *  @brief operations to test for timing differences based on inputs
  */
 
@@ -42,6 +42,10 @@
 
 #ifndef SB_TIME_H
 #define SB_TIME_H
+
+#ifndef SB_TIME
+#define SB_TIME 0
+#endif
 
 #if SB_TIME
 #include <valgrind/memcheck.h>

--- a/src/sb_time.h
+++ b/src/sb_time.h
@@ -1,5 +1,5 @@
-/** @file sb_error.h
- *  @brief private error return macros
+/** @file sb_time.ch
+ *  @brief operations to test for timing differences based on inputs
  */
 
 /*
@@ -39,64 +39,34 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SB_ERROR_H
-#define SB_ERROR_H
 
-#include "sb_types.h"
-#include "sb_time.h"
+#ifndef SB_TIME_H
+#define SB_TIME_H
 
-#include <string.h>
+#include "../valgrind/memcheck.h"
 
-#define SB_NULLIFY(ptr) do { \
-    memset((ptr), 0, sizeof(*(ptr))); \
-} while (0)
-
-#define SB_ERROR_IF(err, cond) ((-(sb_error_t) (cond)) & (sb_error_t) \
-SB_ERROR_## err)
-
-#define SB_RETURN_ERRORS_2(err, zero_ctx) do { \
-    sb_unpoison_output(&err, sizeof(sb_error_t)); \
-    if (err) { \
-        SB_NULLIFY(zero_ctx); \
-        return err; \
-    } \
-} while (0)
-
-#define SB_RETURN_ERRORS_1(err, unused) do { \
-    sb_unpoison_output(&err, sizeof(sb_error_t)); \
-    if (err) { \
-        return err; \
-    } \
-} while (0)
-
-#define SB_RETURN_ERRORS_n(a, b, c, ...) c(a, b)
-
-#define SB_RETURN_ERRORS(...) \
-    SB_RETURN_ERRORS_n(__VA_ARGS__, SB_RETURN_ERRORS_2, SB_RETURN_ERRORS_1, \
-                       NOT_ENOUGH_ARGUMENTS)
-
-#define SB_RETURN(err, zero_ctx) do { \
-    SB_NULLIFY(zero_ctx); \
-    return err; \
-} while (0)
-
-#define SB_ERRORS_4(err1, err2, err3, err4) \
-    (((sb_error_t) (err1)) | ((sb_error_t) (err2)) | ((sb_error_t) (err3)) | \
-     ((sb_error_t) (err4)))
-
-#define SB_ERRORS_3(err1, err2, err3, unused) \
-    (((sb_error_t) (err1)) | ((sb_error_t) (err2)) | ((sb_error_t) (err3)))
-
-#define SB_ERRORS_2(err1, err2, unused1, unused2) \
-    (((sb_error_t) (err1)) | ((sb_error_t) (err2)))
-
-#define SB_ERRORS_1(err1, unused1, unused2, unused3) \
-    ((sb_error_t) (err1))
-
-#define SB_ERRORS_n(a, b, c, d, e, ...) e(a, b, c, d)
-
-#define SB_ERRORS(...) \
-    SB_ERRORS_n(__VA_ARGS__, SB_ERRORS_4, SB_ERRORS_3, SB_ERRORS_2, \
-        SB_ERRORS_1, NOT_ENOUGH_ARGUMENTS)
+/** 
+ * Poisons a memory region of len bytes, starting at addr, indicating that
+ * execution time must not depend on the content of this memory region.
+ * This function is used to mark all fields that contain or are derived from 
+ * secret data.
+ */
+#ifdef SB_TIME
+#define sb_poison_input(addr, len) VALGRIND_MAKE_MEM_UNDEFINED(addr, len)
+#else
+#define sb_poison_input(addr, len) do { /* Nothing */ } while (0)
+#endif
+/**
+ * Removes the poison indicatior from a memory region of len bytes, starting
+ * at addr, to signify that execution time is allowed to depend on the content
+ * of this memory region. This function is used either on invalid input to 
+ * indicate that we no do not make any timing guarantees on invalid data, or 
+ * to prevent propagation of a poisoned state object to all of its output.
+ */
+#ifdef SB_TIME
+#define sb_unpoison_output(addr, len) VALGRIND_MAKE_MEM_DEFINED(addr, len)
+#else
+#define sb_unpoison_output(addr, len) do { /* Nothing */ } while (0)
+#endif
 
 #endif


### PR DESCRIPTION
Marks all public and private key material and inputs to drbg/hmac/sha as undefined (poisoned) so that valgrind's memcheck tool can ensure that these fields and all outputs that depend on these fields are not a source of timing differences. None of the functionality of sweet-b should change.

Some fields are "unpoisoned" in order to prevent the tool from generating false positives, but this should occur only when necessary. 

CMakeLists has been modified to enable manual runs of valgrind. Notably the "-g -O0" compilation flags are added to ensure that valgrind can locate the source of timing difference and the SB_DEBUG_ASSERTS flag has been disabled.

To run the test, build sweet-b and run `valgrind --track-origins=yes ./sb_test`