### PR TITLE
Correct point decompression/compression and handling of points with X coordinate zero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ callgrind.out.*
 *.dSYM
 .vscode
 sb_test
+build

--- a/src/sb_fe.h
+++ b/src/sb_fe.h
@@ -678,6 +678,18 @@ extern void sb_fe_mod_reduce(sb_fe_t dest[static restrict 1],
                              const sb_prime_field_t p[static restrict 1]);
 
 /**
+ * @brief Constant-time modular full reduction.
+ * 
+ * Restores a quasi-reduced value in the range [1, p] to one that is
+ * reduced to the range [0, p - 1].
+ * 
+ * @param [in,out] dest The field element to be fully reduced.
+ * @param [in] p The prime field to compute the reduction with respect to.
+ */
+extern void sb_fe_mod_reduce_full(sb_fe_t dest[static restrict 1],
+                                  const sb_prime_field_t p[static restrict 1]);
+
+/**
  * @brief Constant-time modular addition.
  *
  * Places the quasi-reduced result of the modular addition \p left + \p right
@@ -709,6 +721,23 @@ extern void sb_fe_mod_add(sb_fe_t dest[static 1],
 extern void sb_fe_mod_double(sb_fe_t dest[static 1],
                              const sb_fe_t left[static 1],
                              const sb_prime_field_t p[static 1]);
+
+/**
+ * @brief Constant-time modular halving.
+ *
+ * Places the quasi-reduced result of the modular halving \p left / 2 in \p
+ * dest.
+ *
+ * @param [out] dest Result of the modular halving. May alias \p left.
+ * @param [in] left The value to be halved.
+ * @param [in] temp A temporary field element to use in the computation.
+ * @param [in] p The prime field for the modular operation.
+ */
+
+extern void sb_fe_mod_halve(sb_fe_t dest[static 1],
+                            const sb_fe_t left[static 1],
+                            sb_fe_t temp[static 1],
+                            const sb_prime_field_t p[static 1]);
 
 /**
  * @brief Constant-time modular subtraction.

--- a/src/sb_sw_curves.h
+++ b/src/sb_sw_curves.h
@@ -256,6 +256,15 @@ static const sb_sw_curve_t SB_CURVE_SECP256K1 = {
                        0xC7B977CC32E0BAA9, 0xC374BB2A1315A22F,
                        &SB_CURVE_SECP256K1_P)
     },
+    // There is no point with an X coordinate of 0 on this
+    // curve, but quasi-reduced values for dz_r still must be
+    // supplied.
+    .dz_r = {
+        SB_FE_CONST_QR(0, 0, 0, 1,
+                       &SB_CURVE_SECP256K1_P),
+        SB_FE_CONST_QR(0, 0, 0, 1,
+                       &SB_CURVE_SECP256K1_P)
+    },
     .id = SB_SW_CURVE_SECP256K1
 };
 

--- a/src/sb_sw_curves.h
+++ b/src/sb_sw_curves.h
@@ -67,6 +67,7 @@ typedef struct sb_sw_curve_t {
     // multiplied by R
     sb_fe_pair_t h_r; // H = (2^257 - 1)^-1 * G, with X and Y multiplied by R
     sb_fe_pair_t g_h_r; // G + H, with X and Y multiplied by R
+    sb_fe_pair_t dz_r; // 2 * (0, √𝐵) where √𝐵 has sign bit 0, if such a point exists
     sb_sw_curve_id_t id; // the curve ID for this curve
 } sb_sw_curve_t;
 
@@ -156,6 +157,12 @@ static const sb_sw_curve_t SB_CURVE_P256 = {
                        &SB_CURVE_P256_P),
         SB_FE_CONST_QR(0xD041EE1CCC6223C9, 0xCD81EFC57B6F0943,
                        0xC614355C4D10A425, 0x3A1739581FCABBB7, &SB_CURVE_P256_P)
+    },
+    .dz_r = {
+        SB_FE_CONST_QR(0x2D0F1BE2B5577CF9, 0x8DECDF26C01CE141,
+                       0x07E28A0D562D7881, 0x8218884B2F38E1D6, &SB_CURVE_P256_P),
+        SB_FE_CONST_QR(0x707320391E7826FA, 0x36925B3CB704A1FC,
+                       0xE77DA7D78929B20A, 0x747C0826CD4F4E7B, &SB_CURVE_P256_P)
     },
     .id = SB_SW_CURVE_P256
 };

--- a/src/sb_sw_lib_tests.c.h
+++ b/src/sb_sw_lib_tests.c.h
@@ -436,7 +436,7 @@ _Bool sb_test_p256_dz(void)
     sb_fe_to_bytes(z.bytes + SB_ELEM_BYTES, MULT_POINT_Y(&m), SB_DATA_ENDIAN_BIG);
     // z now holds (0, sqrt(B)) as a serialized point
 
-    *C_X2(&m) = SB_FE_ZERO;
+    *C_X2(&m) = s->p->p;
     sb_fe_mont_convert(C_Y2(&m), &MULT_POINT(&m)->y, s->p);
 
     sb_sw_point_initial_double(&m, s);

--- a/src/sb_sw_lib_tests.c.h
+++ b/src/sb_sw_lib_tests.c.h
@@ -186,6 +186,29 @@ _Bool sb_test_ladder_simple(void)
     SB_TEST_ASSERT(test_ladder_simple(&SB_CURVE_P256.g_r, &SB_CURVE_P256));
     SB_TEST_ASSERT(test_ladder_simple(&SB_CURVE_P256.h_r, &SB_CURVE_P256));
     SB_TEST_ASSERT(test_ladder_simple(&SB_CURVE_P256.g_h_r, &SB_CURVE_P256));
+
+    // Testing for (0, sqrt(B))
+    for (sb_word_t sign = 0; sign <= 1; sign++) {
+        const sb_sw_curve_t* const s = &SB_CURVE_P256;
+        sb_sw_context_t m;
+        SB_NULLIFY(&m); // entire structure is now zeroed
+
+        SB_TEST_ASSERT(sb_sw_point_decompress(&m, sign, s));
+        // MULT_POINT(&m) now holds (0, sqrt(B))
+
+        sb_double_t z;
+        SB_NULLIFY(&z);
+        sb_fe_to_bytes(z.bytes + SB_ELEM_BYTES, MULT_POINT_Y(&m), SB_DATA_ENDIAN_BIG);
+        // z now holds (0, sqrt(B)) as a serialized point
+
+        sb_fe_pair_t zp;
+
+        zp.x = s->p->p;
+        sb_fe_mont_convert(&zp.y, &MULT_POINT(&m)->y, s->p);
+
+        SB_TEST_ASSERT(test_ladder_simple(&zp, &SB_CURVE_P256));
+    }
+
     SB_TEST_ASSERT(
         test_ladder_simple(&SB_CURVE_SECP256K1.g_r, &SB_CURVE_SECP256K1));
     SB_TEST_ASSERT(

--- a/src/sb_test_list.h
+++ b/src/sb_test_list.h
@@ -54,6 +54,7 @@ SB_DEFINE_TEST(hkdf);
 // These tests are for general field operations
 // and can be found in sb_fe_tests.c.h
 SB_DEFINE_TEST(fe);
+SB_DEFINE_TEST(mod_double);
 SB_DEFINE_TEST(mont_mult);
 SB_DEFINE_TEST(mont_mult_overflow);
 SB_DEFINE_TEST(mod_expt_p);
@@ -69,6 +70,7 @@ SB_DEFINE_TEST(ladder_simple);
 SB_DEFINE_TEST(secp256k1_endomorphism);
 SB_DEFINE_TEST(exceptions);
 SB_DEFINE_TEST(sw_h);
+SB_DEFINE_TEST(p256_dz);
 SB_DEFINE_TEST(sw_point_mult_add);
 // Known answer tests for keygen, shared_secret, and sign/verify work as they
 // should.
@@ -79,6 +81,7 @@ SB_DEFINE_TEST(valid_private);
 SB_DEFINE_TEST(valid_public);
 SB_DEFINE_TEST(shared_secret);
 SB_DEFINE_TEST(shared_secret_cavp_1);
+SB_DEFINE_TEST(p256_zero_x);
 SB_DEFINE_TEST(shared_secret_secp256k1);
 SB_DEFINE_TEST(sign_rfc6979);
 SB_DEFINE_TEST(sign_rfc6979_sha256);


### PR DESCRIPTION
* Point decompression and compression used the wrong bit for the "sign" due to an off-by-one error. Fix these routines and enhance the unit tests to assert that the correct bit is used.
* The handling of the P-256 points with X coordinate zero was incorrect in that the curve prime `p` was output in some circumstances were zero should have been output. This is due to the "quasi-reduction" strategy used by Sweet B. Add a new routine to fully reduce the output and invoke it in the appropriate places.
* Multiplication by P-256 points with X coordinate zero fails due to the Z recovery algorithm used in converting projective coordinates to affine coordinates at the end of the Montgomery ladder. When multiplying by these points, double the input point and halve the input scalar to perform an equivalent computation that can be completed successfully. Also, ensure that the output is not written before errors are returned.

Fixes issues #18, #19 and CVEs CVE-2022-23001, CVE-2022-23002, CVE-2022-23003, and CVE-2022-23004. For more information, see [Western Digital security bulletin WDC-22013](https://www.westerndigital.com/support/product-security/wdc-22013-sweet-b-incorrect-output-vulnerabilities).